### PR TITLE
Add Docker support and fix Base32 Padding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,11 @@
 ### Dockerfile for nz-covid-pass-verifier
 
-# Plpine POS 3.8
+# Python Alpine
 FROM python:alpine
 
 RUN set -x \
     && apk add --no-cache gcc py3-cffi libc-dev jpeg-dev libffi-dev zbar-dev \
     && rm -rf /var/cache/apk/*
-
-#RUN set -x \
-#    && apk add --no-cache ython2-dev py2-openssl python3 \
-#    && rm -rf /var/cache/apk/*
 
 WORKDIR /app
 
@@ -17,7 +13,6 @@ COPY . .
 
 RUN set -x \
      && pip install -r requirements.txt
-
 
 ENTRYPOINT ["python3", "nz_covid_pass_verifier.py"]
 #ENTRYPOINT /bin/sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+### Dockerfile for nz-covid-pass-verifier
+
+# Plpine POS 3.8
+FROM python:alpine
+
+RUN set -x \
+    && apk add --no-cache gcc py3-cffi libc-dev jpeg-dev libffi-dev zbar-dev \
+    && rm -rf /var/cache/apk/*
+
+#RUN set -x \
+#    && apk add --no-cache ython2-dev py2-openssl python3 \
+#    && rm -rf /var/cache/apk/*
+
+WORKDIR /app
+
+COPY . .
+
+RUN set -x \
+     && pip install -r requirements.txt
+
+
+ENTRYPOINT ["python3", "nz_covid_pass_verifier.py"]
+#ENTRYPOINT /bin/sh
+#CMD /bin/sh
+

--- a/README.md
+++ b/README.md
@@ -10,8 +10,15 @@ learning and experimentation.
 ## Installing
 
 ```
-$ pip3 install -r requirements.txt
 $ sudo apt-get install python3-zbar
+$ pip3 install -r requirements.txt
+```
+
+## Docker
+
+```
+docker build -t nzcovidpass .
+docker run -v $(pwd):/app/qr --rm nzcovidpass --qrcode-file /app/qr/Image.jpg
 ```
 
 ## Usage

--- a/nz_covid_pass_verifier.py
+++ b/nz_covid_pass_verifier.py
@@ -95,6 +95,11 @@ def main():
             # Invalid
             continue
 
+        # Add Base32 padding back on if needed: https://nzcp.covid19.health.nz/#2d-barcode-encoding
+        unpadded_length = len(qrcode_data_segments[2]) % 8
+        if unpadded_length != 0:
+            qrcode_data_segments[2] += (8 - unpadded_length) * '='
+
         # Decode base32 payload inside QR code
         qrcode_payload = base64.b32decode(qrcode_data_segments[2])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+poetry
 cwt
 Pillow
 pyyaml


### PR DESCRIPTION
Small PR as your code is far cleaner than mine. 👍 

Having a docker for ease of deployment as depending on the environment base packages need to be added.

Also added in support for Base32 padding, as the examples don't need it, but real entries I have tested with do.